### PR TITLE
Added detection for livewire component name

### DIFF
--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -91,6 +91,15 @@ function handleMessages(e) {
 
 // See https://github.com/Te7a-Houdini/alpinejs-devtools/issues/28#issuecomment-616719252
 function getComponentName(element) {
+    if (element.id) {
+        return element.id
+    }
+    
+    const nameAttr = element.getAttribute('name');
+    if (nameAttr) {
+        return nameAttr
+    }
+
     const wireIdAttr = element.getAttribute('wire:id');
     if (wireIdAttr && window.livewire) {
         try {
@@ -101,19 +110,13 @@ function getComponentName(element) {
             }
         } catch(e) {}
     }
-    
-    if (element.id) {
-        return element.id
-    }
-    const nameAttr = element.getAttribute('name');
-    if (nameAttr) {
-        return nameAttr
-    }
+
     const xDataAttr = element.getAttribute('x-data').trim();
     // match `x-data="someFunctionName()"` but not `x-data="{ hello: 'world' }"`
     if (xDataAttr.endsWith(")") && !xDataAttr.startsWith("{")) {
         return xDataAttr.split('(')[0]
     }
+    
     const roleAttr = element.getAttribute('role');
     if (roleAttr) {
         return roleAttr;

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -106,7 +106,7 @@ function getComponentName(element) {
             const wire = window.livewire.find(wireIdAttr);
 
             if(wire.__instance){
-                return wire.__instance.fingerprint.name;
+                return 'livewire:' + wire.__instance.fingerprint.name;
             }
         } catch(e) {}
     }

--- a/packages/shell-chrome/src/backend.js
+++ b/packages/shell-chrome/src/backend.js
@@ -91,6 +91,17 @@ function handleMessages(e) {
 
 // See https://github.com/Te7a-Houdini/alpinejs-devtools/issues/28#issuecomment-616719252
 function getComponentName(element) {
+    const wireIdAttr = element.getAttribute('wire:id');
+    if (wireIdAttr && window.livewire) {
+        try {
+            const wire = window.livewire.find(wireIdAttr);
+
+            if(wire.__instance){
+                return wire.__instance.fingerprint.name;
+            }
+        } catch(e) {}
+    }
+    
     if (element.id) {
         return element.id
     }


### PR DESCRIPTION
Hey guys, thanks for developing this tool! Hope you don't mind me chiming in. This pull request adds the detection of a Livewire component name in the `getComponentName` method. I've left it further down in priority below the `id` and `name` attribute detection as I guess you may want to be able to override a Livewire component name with something custom.

Alternatively `getComponentName` could potentially return an object depending on what's been detected?
```
{
    name: 'foo',
    type: 'livewire'
    id: 'bar'
}
```
Giving the option for a component in the tree to display as "name#id" with its colour corresponding to type and the id portion more muted in style. Can have a crack at an implementation if you're interested.

Closes #53 